### PR TITLE
Fix project name in metadata

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -4,11 +4,11 @@
     "version": "v0.11",
     "meta-version": "0",
     "license": "",
-    "source-url": "https://github.com/Xliff/p6-RandomColor.git",
+    "source-url": "https://github.com/Xliff/raku-RandomColor.git",
     "provides": {
       "RandomColor": "lib/RandomColor.pm6"
     },
-    "name": "p6-RandomColor",
+    "name": "raku-RandomColor",
     "perl": "6.c",
     "test-depends": ["Test::META"],
     "build-depends": [],


### PR DESCRIPTION
The project was renamed after Raku became Raku, hence the `source-url` mentioned in the project's metadata was out of date.  Also the project's name also seemed to be updated to use Raku rather than mention Perl6. This commit brings the metadata up to date with the current state of the project.

This PR is submitted in the hope that it is useful. If you want anything changed, please let me know and I'll update and resubmit as necessary.